### PR TITLE
Query Magisk su-policy DB without the bundled 32-bit sqlite3

### DIFF
--- a/app/src/main/java/com/zalexdev/stryker/utils/Core.java
+++ b/app/src/main/java/com/zalexdev/stryker/utils/Core.java
@@ -941,15 +941,31 @@ public class Core {
     public boolean checkMagiskNotification(){
         reCreateProcess();
         if (!getBoolean("offed")){
-        String cmd = "/data/data/com.zalexdev.stryker/files/sqlite3 /data/adb/magisk.db \"SELECT notification FROM policies WHERE package_name='com.zalexdev.stryker';\"";
-        boolean b = Core.contains(customCommand(cmd),"1");
+        boolean b = Core.contains(magiskSql("SELECT notification FROM policies WHERE package_name='com.zalexdev.stryker';"),"1");
         if (!b) {
-            cmd = "/data/data/com.zalexdev.stryker/files/sqlite3 /data/adb/magisk.db \"SELECT notification FROM policies WHERE uid='"+android.os.Process.myUid()+"';\"";
-            b = Core.contains(customCommand(cmd),"1");
+            b = Core.contains(magiskSql("SELECT notification FROM policies WHERE uid='"+android.os.Process.myUid()+"';"),"1");
         }
         return b;}else{
             return false;
         }
+    }
+
+    // SQL against Magisk's su-policy database. Magisk 20.3+ ships its own sqlite frontend
+    // (`magisk --sqlite`), which works on every arch; the binary bundled with the app is
+    // 32-bit ARM and fails with "not executable" on 64-bit-only devices, so /system/bin/sqlite3
+    // is preferred over it. KernelSU and other managers have no magisk.db at all — return
+    // nothing instead of shelling out.
+    private ArrayList<String> magiskSql(String sql){
+        if (contains(customCommand("[ -x /data/adb/magisk ] && echo true || echo false"),"true")){
+            return customCommand("/data/adb/magisk --sqlite \"" + sql + "\"");
+        }
+        if (!contains(customCommand("[ -f /data/adb/magisk.db ] && echo true || echo false"),"true")){
+            return new ArrayList<>();
+        }
+        if (contains(customCommand("[ -x /system/bin/sqlite3 ] && echo true || echo false"),"true")){
+            return customCommand("/system/bin/sqlite3 /data/adb/magisk.db \"" + sql + "\"");
+        }
+        return customCommand("/data/data/com.zalexdev.stryker/files/sqlite3 /data/adb/magisk.db \"" + sql + "\"");
     }
 
     public boolean checkRoot(){
@@ -1506,16 +1522,12 @@ public class Core {
 
     public void disableMagiskNotification() {
 
-                if (contains(customCommand("/data/data/com.zalexdev.stryker/files/sqlite3 "
-                        + "/data/adb/magisk.db"
-                        + " \"UPDATE policies SET logging='0',notification='0' WHERE package_name='"
+                if (contains(magiskSql("UPDATE policies SET logging='0',notification='0' WHERE package_name='"
                         + "com.zalexdev.stryker"
-                        + "';\""), "no such"))
-                {customCommand("/data/data/com.zalexdev.stryker/files/sqlite3 "
-                                        + "/data/adb/magisk.db"
-                                        + " \"UPDATE policies SET logging='0',notification='0' WHERE uid='"
-                                        + android.os.Process.myUid()
-                                        + "';\"");}
+                        + "';"), "no such"))
+                {magiskSql("UPDATE policies SET logging='0',notification='0' WHERE uid='"
+                        + android.os.Process.myUid()
+                        + "';");}
     }
 
 


### PR DESCRIPTION
## Problem

Every app launch logs this error (visible in Settings → Debug):

```
/data/data/com.zalexdev.stryker/files/sqlite3: not executable: 32-bit ELF file
```

`checkMagiskNotification()` / `disableMagiskNotification()` unconditionally
shell out to the sqlite3 binary bundled in assets, which is a **32-bit ARM
ELF**. Devices that ship 64-bit-only arm64 builds (no 32-bit ABI support —
increasingly common on new hardware) cannot exec it at all, so the
Magisk su-notification check fails on every launch.

## Fix

Both methods now go through a new private `magiskSql(String)` helper with a
fallback chain:

1. **`magisk --sqlite "..."`** — Magisk 20.3+ ships its own sqlite frontend that works on every arch
2. **No `/data/adb/magisk.db`?** → return empty immediately. KernelSU, KernelSU-Next, APatch and other managers have no Magisk policy DB at all — shelling out can never produce a useful result, so don't
3. **`/system/bin/sqlite3`** — some ROMs ship a native sqlite3; prefer it over the bundled binary
4. **Bundled 32-bit binary** — last resort, still works on 32-bit devices

## Verification

On a 64-bit-only arm64 device (Android 17, KernelSU-Next):

- Fresh launch logs show the new probe sequence: `[ -x /data/adb/magisk ]` → false, `[ -f /data/adb/magisk.db ]` → false → early return, no sqlite3 exec attempt
- Zero `sqlite3` / `not executable` entries in the debug log DB after relaunch
- On Magisk 20.3+ devices branch 1 is exercised instead (binary verified present/runnable on-device where available)
