### PR TITLE
Add optional toggle to allow deauth on the internal Wi-Fi radio

### DIFF
--- a/app/src/main/java/com/zalexdev/stryker/settings/SettingsHomeFragment.java
+++ b/app/src/main/java/com/zalexdev/stryker/settings/SettingsHomeFragment.java
@@ -61,6 +61,9 @@ public class SettingsHomeFragment extends Fragment {
         SwitchMaterial autoBanner = view.findViewById(R.id.banner_detect);
         SwitchMaterial pixieIfaceDown = view.findViewById(R.id.pixie_iface_down_switch);
         LinearLayout pixieIfaceDownRow = view.findViewById(R.id.pixie_iface_down_row);
+        LinearLayout internalDeauthRow = view.findViewById(R.id.internal_deauth_row);
+        View internalDeauthDivider = view.findViewById(R.id.internal_deauth_divider);
+        SwitchMaterial internalDeauth = view.findViewById(R.id.internal_deauth_switch);
         LinearLayout autoWifiRow = view.findViewById(R.id.autowifi_row);
         LinearLayout saveApsRow = view.findViewById(R.id.save_aps_row);
         LinearLayout autoScanRow = view.findViewById(R.id.autoscan_row);
@@ -81,6 +84,7 @@ public class SettingsHomeFragment extends Fragment {
         saveAps.setChecked(core.isStoreEnabled());
         autoBanner.setChecked(core.isBannerScanEnabled());
         pixieIfaceDown.setChecked(core.isPixieIfaceDown());
+        internalDeauth.setChecked(core.isInternalDeauthEnabled());
         hide.setChecked(core.getBoolean("hide"));
         autoWifi.setChecked(core.getBoolean("wifi"));
         autoScan.setChecked(core.getBoolean("autoScan"));
@@ -89,6 +93,7 @@ public class SettingsHomeFragment extends Fragment {
         saveAps.setOnCheckedChangeListener((btn, b) -> core.putBoolean("save_aps", b));
         autoBanner.setOnCheckedChangeListener((btn, b) -> core.putBoolean("autoBanner", b));
         pixieIfaceDown.setOnCheckedChangeListener((btn, b) -> core.putBoolean("pixie_iface_down", b));
+        internalDeauth.setOnCheckedChangeListener((btn, b) -> core.putBoolean("internal_deauth", b));
         hide.setOnCheckedChangeListener((btn, b) -> core.putBoolean("hide", b));
         autoWifi.setOnCheckedChangeListener((btn, b) -> core.putBoolean("wifi", b));
         autoScan.setOnCheckedChangeListener((btn, b) -> core.putBoolean("autoScan", b));
@@ -96,6 +101,12 @@ public class SettingsHomeFragment extends Fragment {
         bindRowToSwitch(autoWifiRow, autoWifi);
         bindRowToSwitch(saveApsRow, saveAps);
         bindRowToSwitch(pixieIfaceDownRow, pixieIfaceDown);
+        bindRowToSwitch(internalDeauthRow, internalDeauth);
+        if (core.isRootless()) {
+            // The internal radio doesn't exist in the rootless VM — the toggle has no effect there
+            internalDeauthRow.setVisibility(View.GONE);
+            internalDeauthDivider.setVisibility(View.GONE);
+        }
         bindRowToSwitch(autoScanRow, autoScan);
         bindRowToSwitch(bannerRow, autoBanner);
         bindRowToSwitch(hideRow, hide);

--- a/app/src/main/java/com/zalexdev/stryker/utils/Core.java
+++ b/app/src/main/java/com/zalexdev/stryker/utils/Core.java
@@ -1387,6 +1387,10 @@ public class Core {
         return preferences.getBoolean("pixie_iface_down", true);
     }
 
+    public boolean isInternalDeauthEnabled(){
+        return preferences.getBoolean("internal_deauth", false);
+    }
+
     public String wpsIfaceDownFlag(){
         return isPixieIfaceDown() ? " --iface-down" : "";
     }

--- a/app/src/main/java/com/zalexdev/stryker/wifi/WiFIAdapter.java
+++ b/app/src/main/java/com/zalexdev/stryker/wifi/WiFIAdapter.java
@@ -678,10 +678,11 @@ public class WiFIAdapter extends RecyclerView.Adapter<WiFIAdapter.ViewHolder> {
                     String wlanscan = core.getHSInterface();
                     String deauthPref = core.getDeauthInterface();
                     ArrayList<String> clients = new ArrayList<>();
-                    if (!core.isRootless() && MonitorManager.isInternalRadio(deauthPref)){
+                    if (!core.isRootless() && !core.isInternalDeauthEnabled()
+                            && MonitorManager.isInternalRadio(deauthPref)){
                         if (!MonitorManager.isInternalRadio(wlanscan)) {
                             deauthPref = wlanscan;
-                            sendEvent("Deauth interface is the internal radio — using " + wlanscan + " instead");
+                            sendEvent("Deauth interface is the internal radio — using " + wlanscan + " instead (enable 'Deauth with internal adapter' in Settings to use it)");
                         } else {
                             deauth = false;
                         }
@@ -787,6 +788,7 @@ public class WiFIAdapter extends RecyclerView.Adapter<WiFIAdapter.ViewHolder> {
                                     ? wlandeauth + "mon" : wlandeauth;
                             final String hsIface = capIface;
                             final boolean internalDeauth = !core.isRootless()
+                                    && !core.isInternalDeauthEnabled()
                                     && MonitorManager.isInternalRadio(deauthIface);
                             final String[] lastRelock = {""};
                             if (deauth) {
@@ -1295,10 +1297,11 @@ public class WiFIAdapter extends RecyclerView.Adapter<WiFIAdapter.ViewHolder> {
             if (dialogCanceled.get()) return;
             String deauthIface = core.getDeauthInterface();
             boolean ok = false;
-            if (core.isRootless() || !MonitorManager.isInternalRadio(deauthIface)){
+            if (core.isRootless() || !MonitorManager.isInternalRadio(deauthIface)
+                    || core.isInternalDeauthEnabled()){
                 ok = core.enableMonitorMode(deauthIface, String.valueOf(network.getChannel()));
             }else{
-                activity.runOnUiThread(() -> outputtext.append("Internal wifi adapter (wlan0) does not support packet injection! Please use external wifi adapter!\n"));
+                activity.runOnUiThread(() -> outputtext.append("Internal wifi adapter (wlan0) deauth is disabled! Enable 'Deauth with internal adapter' in Settings, or use an external wifi adapter!\n"));
             }
             if (dialogCanceled.get()) return;
             final String monIface = core.getDeauthInterface();

--- a/app/src/main/res/layout/settings_main.xml
+++ b/app/src/main/res/layout/settings_main.xml
@@ -333,6 +333,68 @@
                     android:background="@color/light_lite_contrast" />
 
                 <LinearLayout
+                    android:id="@+id/internal_deauth_row"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:minHeight="64dp"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingTop="12dp"
+                    android:paddingEnd="14dp"
+                    android:paddingBottom="12dp">
+
+                    <ImageView
+                        android:layout_width="44dp"
+                        android:layout_height="44dp"
+                        android:background="@drawable/settings_icon_bg"
+                        android:padding="10dp"
+                        android:src="@drawable/deauth"
+                        app:tint="@color/stryker_accent" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="14dp"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_internal_deauth_title"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textSize="16sp"
+                            android:textStyle="bold" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/settings_internal_deauth_subtitle"
+                            android:textColor="@color/grey"
+                            android:textSize="12sp" />
+                    </LinearLayout>
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/internal_deauth_switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:clickable="false"
+                        android:focusable="false" />
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/internal_deauth_divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginStart="72dp"
+                    android:background="@color/light_lite_contrast" />
+
+                <LinearLayout
                     android:id="@+id/change_interfaces"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,8 @@ Storage is only consumed as the guest writes, and space freed inside the VM is r
     <string name="settings_change_interfaces_subtitle">Pick which adapter handles scan, handshake, deauth, WPS</string>
     <string name="settings_pixie_iface_down_title">Turn interface down</string>
     <string name="settings_pixie_iface_down_subtitle">Disable Wi‑Fi and drop the adapter during Pixie/WPS attacks. Needed for most internal adapters; turn off for external adapters that must stay up</string>
+    <string name="settings_internal_deauth_title">Deauth with internal adapter</string>
+    <string name="settings_internal_deauth_subtitle">Allow deauthentication on the internal Wi‑Fi radio (wlan0). Enable only if your device supports packet injection on the internal adapter; otherwise an external adapter is used</string>
 
     <string name="settings_change_commands_title">Custom monitor commands</string>
     <string name="settings_change_commands_subtitle">Override how monitor mode is enabled per adapter</string>


### PR DESCRIPTION
## Problem

The app hard-assumed the internal Wi-Fi radio (`wlan0`/`swlan0`) can never perform deauthentication. In the handshake attack (type 3) the deauth interface was silently swapped to the scan adapter, or deauth was skipped entirely; in the standalone deauth dialog (type 7) the attack was refused outright with "internal wifi adapter does not support packet injection".

That assumption is wrong for devices whose internal radio *does* support monitor mode and injection — e.g. Qualcomm qcacld chipsets, where `airmon-ng start wlan0` creates a working `wlan0mon` monitor vif.

## Fix

Gate the old behavior behind a new Settings switch — **"Deauth with internal adapter"** — rather than removing it, so devices whose internal radio genuinely cannot inject keep the current safe behavior:

- **Off (default)**: exactly the previous behavior — internal-radio deauth interfaces are swapped to the scan adapter (with a message that now mentions the setting), or deauth is skipped / refused as before
- **On**: the internal radio is allowed as a deauth interface in both the handshake attack and the standalone deauth dialog

The toggle lives next to the existing internal-adapter settings and is hidden in rootless mode (no internal radio exists in the VM there).

## Deliberately out of scope

Monitor-mode enable/disable commands are untouched. Devices that need `airmon-ng` for the internal radio can already configure that per adapter via **Settings → Custom monitor commands** — no fallbacks or auto-detection were added.

Verified on a Xiaomi 25053PC47G (Android 17, KernelSU-Next, qcacld `qca_cld3_wcn7750`): with `airmon-ng` commands configured on the internal adapter card and the toggle enabled, deauth runs on `wlan0mon`.
