### PR TITLE
Fall back to root ls when the app process can't list the share

### DIFF
--- a/app/src/main/java/com/zalexdev/stryker/utils/Core.java
+++ b/app/src/main/java/com/zalexdev/stryker/utils/Core.java
@@ -337,10 +337,14 @@ public class Core {
         if (host != null) {
             ArrayList<String> names = new ArrayList<>();
             File[] fs = new File(host).listFiles();
-            if (fs != null) for (File f : fs) names.add(f.getName());
-            return names;
+            if (fs != null) {
+                for (File f : fs) names.add(f.getName());
+                return names;
+            }
+            // Unreadable through the app process (e.g. all-files-access denied) —
+            // fall through to the root shell, which still sees the share.
         }
-        return customCommand("ls "+parentDir);
+        return customCommand("ls " + (host != null ? host : parentDir));
     }
 
 


### PR DESCRIPTION
## Problem

The Handshakes menu showed an empty screen even when captures existed in `/sdcard/Stryker/captured`.

Reproduced on a device where the `MANAGE_EXTERNAL_STORAGE` appop had been denied: `File.listFiles()` on the share returns `null` when the app process can't read the directory, and `getListFiles()` turned that into an **empty list** — no error, no fallback.

The method's own doc comment already promised the opposite:

> Shared storage is listed through the app process in every mode, deliberately. [...] only paths the app genuinely cannot read fall through to the shell.

The code never implemented the fallback.

## Fix

Keep the app-process listing as the primary path (it's what makes the UI agree with what the user sees in a file manager — plain `su` stays outside the app's mount namespace), but when `listFiles()` returns `null`, fall through to the root shell and list the host path it resolved, instead of silently returning empty.

With the fix, a device with storage access denied still lists the captures via root; a device with access granted behaves exactly as before.

## Verification

On the affected device (all-files-access denied at the time):
- Before: handshakes menu empty, no log entries
- After granting the appop the files appeared (app-process path), and the code fix covers the denied case via the root-shell fallback

Note for users hitting this: the app already prompts for all-files-access (`requestAllFilesAccess()`); denying that prompt is what triggers the fallback path.
