### PR TITLE
Parse current OnlineHashCrack API response format

### DIFF
--- a/app/src/main/java/com/zalexdev/stryker/handshakes/HandshakesAdapter.java
+++ b/app/src/main/java/com/zalexdev/stryker/handshakes/HandshakesAdapter.java
@@ -281,6 +281,25 @@ public class HandshakesAdapter extends RecyclerView.Adapter<HandshakesAdapter.Vi
                     boolean already = message.toLowerCase(java.util.Locale.ROOT).contains("already");
                     return new UploadResult(already ? UploadOutcome.ALREADY : UploadOutcome.SUCCESS, message);
                 }
+                // Current OnlineHashCrack API responds with accepted/skipped/rejected counts
+                // instead of a success flag: {"accepted":{"count":1,...},"skipped":{...},"rejected":{...}}
+                org.json.JSONObject accepted = json.optJSONObject("accepted");
+                org.json.JSONObject skipped = json.optJSONObject("skipped");
+                org.json.JSONObject rejected = json.optJSONObject("rejected");
+                if (accepted != null || skipped != null || rejected != null) {
+                    int acc = accepted != null ? accepted.optInt("count", 0) : 0;
+                    int skp = skipped != null ? skipped.optInt("count", 0) : 0;
+                    int rej = rejected != null ? rejected.optInt("count", 0) : 0;
+                    if (acc > 0) {
+                        return new UploadResult(UploadOutcome.SUCCESS, message);
+                    }
+                    if (skp > 0) {
+                        String reason = skipped != null ? skipped.optString("reason", "") : "";
+                        return new UploadResult(UploadOutcome.ALREADY, reason);
+                    }
+                    String reason = rejected != null ? rejected.optString("reason", "") : "";
+                    return new UploadResult(UploadOutcome.FAILED, reason);
+                }
                 return new UploadResult(UploadOutcome.FAILED, message);
             } catch (org.json.JSONException ignored) {
             }


### PR DESCRIPTION
The upload parser expects a response format OnlineHashCrack no longer
uses, so successful uploads are reported as failures.

From the app's debug log DB on a test device, a real upload response:

    {"notice":"...","next_steps":"Results are available in your
    OnlineHashCrack dashboard: https://onlinehashcrack.com/tasks",
    "accepted":{"count":1,"hashes":["WPA*02*..."]},
    "skipped":{"count":0,"reason":"already_sent","hashes":[]},
    "rejected":{"count":0,"hashes":[]}}

The upload itself succeeded (accepted count 1, the hash landed in the
user's OHC dashboard) — but parseUploadResult() only recognizes the
legacy {"success":true,"message":...} shape. It matched nothing, fell
through every branch, and the app toasted a generic upload-failed
message with no detail.

Recognize the current format in the JSON branch:
- accepted.count > 0 -> SUCCESS
- skipped.count > 0 -> ALREADY (with the skip reason, e.g. already_sent)
- otherwise -> FAILED with the rejected reason

The legacy success-flag path is kept for older/other response shapes,
and the non-JSON text fallbacks (already/success/uploaded keywords)
are unchanged.
